### PR TITLE
png 拡張子が小文字でなくてもちゃんと変換する

### DIFF
--- a/png2dds.sh
+++ b/png2dds.sh
@@ -48,9 +48,9 @@ for i in $(cat $File)
 do
     echo "---------------------"
     echo "Target File: ${i}"
-    filename=${i%.png}
+    filename=${i%.*}
     echo "${filename}";
-    convert "${filename}.png" -define dds:compression="$Comp",dds:cluster-fit=true,dds:weight-by-alpha=true,dds:fast-mipmaps=true "${filename}.dds"
+    convert "${i}" -define dds:compression="$Comp",dds:cluster-fit=true,dds:weight-by-alpha=true,dds:fast-mipmaps=true "${filename}.dds"
 done
 
 echo "Remove PNG images? (Y/n)"


### PR DESCRIPTION
png ファイルの拡張子が小文字でないとき foo.PNG.png みたいなファイルを開こうとして変換されないのを修正しました